### PR TITLE
Multiple table support

### DIFF
--- a/Arduino/DJLucio/DJLucio.ino
+++ b/Arduino/DJLucio/DJLucio.ino
@@ -62,7 +62,18 @@ public:
 const long UpdateRate = 4;  // Update frequency in ms
 long lastUpdate = 0;
 
+#define MAIN_TABLE right
+
+#if MAIN_TABLE==right
+#define ALT_TABLE left
+#elif MAIN_TABLE==left
+#define ALT_TABLE right
+#endif
+
 DJTurntableController dj;
+
+DJTurntableController::TurntableExpansion * mainTable = &dj.MAIN_TABLE;
+DJTurntableController::TurntableExpansion * altTable = &dj.ALT_TABLE;
 
 button fire(MOUSE_LEFT, MOUSE);
 button boop(MOUSE_RIGHT, MOUSE);
@@ -113,21 +124,42 @@ void loop() {
 }
 
 void djController() {
-	// Aiming
-	if (dj.buttonMinus()) {  // Vertical selector
-		aiming(0, dj.turntable());
-	}
-	else {
-		aiming(dj.turntable(), 0);
+	// Dual turntables
+	if (dj.getNumTurntables() == 2) {
+		if (!dj.buttonMinus()) {  // Button to disable aiming (for position correction)
+			aiming(mainTable->turntable(), altTable->turntable());
+		}
+
+		// Movement
+		jump.press(mainTable->buttonRed());
+
+		// Weapons
+		fire.press(mainTable->buttonGreen() || mainTable->buttonBlue());  // Outside buttons
+		boop.press(altTable->buttonGreen() || altTable->buttonRed() || altTable->buttonBlue());
 	}
 
+	// Single turntable (either side)
+	else if (dj.getNumTurntables() == 1) {
+		// Aiming
+		if (dj.buttonMinus()) {  // Vertical selector
+			aiming(0, dj.turntable());
+		}
+		else {
+			aiming(dj.turntable(), 0);
+		}
+		
+		// Movement
+		jump.press(dj.buttonRed());
+
+		// Weapons
+		fire.press(dj.buttonGreen());
+		boop.press(dj.buttonBlue());
+	}
+
+
+	// --Base Station Abilities--
 	// Movement
 	joyWASD(dj.joyX(), dj.joyY());
-	jump.press(dj.buttonRed());
-
-	// Weapons
-	fire.press(dj.buttonGreen());
-	boop.press(dj.buttonBlue());
 
 	// Abilities
 	ultimate.press(dj.buttonEuphoria());


### PR DESCRIPTION
Initial support for multiple turntables connected to a single base! The second turntable is mapped to vertical aiming, with all three of its buttons mapped to "boop" (so you can slam the general area, rather than searching for the exact button).

The extra button gained on the first turntable is now also mapped to primary fire, and the vertical aim select button ('-') is now a 'cancel aim' button, for moving turntables without sending mouse movements (re-centering etc.).