### PR TITLE
Fix Disconnect Bug

### DIFF
--- a/Arduino/DJLucio/DJLucio_Controller.h
+++ b/Arduino/DJLucio/DJLucio_Controller.h
@@ -141,7 +141,7 @@ public:
 	boolean isReady() {
 		if (pollRate.ready() && isConnected()) {
 			if (!controller.update()) {  // Fetch new data
-				onDisconnect();
+				disconnect();
 				D_COMMS("Controller update failed :(");
 			}
 			else {
@@ -161,7 +161,7 @@ public:
 		// If so, invalidate any present connection
 		if (!controllerDetected()) {
 			D_COMMS("Controller not detected (check your connections)");
-			if (connected) { onDisconnect(); }  // Disconnect if connected
+			if (connected) { disconnect(); }  // Disconnect if connected
 			return false;  // No controller detected? Nothing else to do here
 		}
 
@@ -184,7 +184,7 @@ private:
 		D_COMMS("Controller successfully connected!");	
 	}
 
-	void onDisconnect() {
+	void disconnect() {
 		HID_Button::releaseAll();  // Something went wrong, clear current pressed buttons
 		LED.write(LOW);  // LED low = disconnected
 		connected = false;


### PR DESCRIPTION
There's a small bug in the auto-connect logic where if a controller disconnects in the controller detect pin stage (`isConnected()`) rather than the update stage, the LED is not cleared and the HID keypresses are not released.

I rewrote the class to use `onConnect` and `disconnect` methods. This should handle both potential disconnect cases.