### PR TITLE
Vertical direction dependent on side

### DIFF
--- a/Arduino/DJLucio/DJLucio.ino
+++ b/Arduino/DJLucio/DJLucio.ino
@@ -110,7 +110,15 @@ void djController() {
 	// Dual turntables
 	if (dj.getNumTurntables() == 2) {
 		if (!dj.buttonMinus()) {  // Button to disable aiming (for position correction)
-			aiming(mainTable->turntable(), altTable->turntable());
+			// Left is vertical, counter-clockwise is up
+			if (altTable == &dj.left) {
+				aiming(mainTable->turntable(), altTable->turntable());
+			}
+			// Right is vertical, clockwise is up
+			else {
+				aiming(mainTable->turntable(), -altTable->turntable());
+			}
+			
 		}
 
 		// Movement
@@ -125,7 +133,15 @@ void djController() {
 	else if (dj.getNumTurntables() == 1) {
 		// Aiming
 		if (dj.buttonMinus()) {  // Vertical selector
-			aiming(0, dj.turntable());
+			// Left is vertical, counter-clockwise is up
+			if (dj.getTurntableConfig() == DJTurntableController::TurntableConfig::Left) { 
+				aiming(0, dj.turntable());
+			}
+			// Right is vertical, clockwise is up
+			else {
+				aiming(0, -dj.turntable());
+			}
+			
 		}
 		else {
 			aiming(dj.turntable(), 0);


### PR DESCRIPTION
Vertical direction is now conditional on turntable side. Previously, the vertical direction for either side (L/R) in either configuration (1/2) was counter-clockwise for 'up'. Now all vertical movement on the right turntable is clockwise for "up", while vertical movement on the left turntable is counter-clockwise for "up".

I went back and forth on this a fair bit through development. Both clockwise and counter-clockwise felt "right", so I just let it be. But after doing the gameplay demos with the single turntable on the right-hand side I think it makes more sense for clockwise to be "up" much like turning the effect dial (and, you know, most other controls in the world).

That being said, I'm keeping the left side as counter-clockwise because in dual turntable mode I keep the buttons along the inside edge, so moving the inside edge "up" (towards the top of the controller, away from the player) feels natural even though it's a counter-clockwise motion. If not identical, I'll settle for the controls being symmetrical.