### PR TITLE
Updated Dependencies (1.0.2)

### DIFF
--- a/Arduino/DJLucio/DJLucio.ino
+++ b/Arduino/DJLucio/DJLucio.ino
@@ -79,7 +79,7 @@ void setup() {
 	#ifdef DEBUG
 	Serial.begin(115200);
 	while (!Serial);  // Wait for connection
-	DEBUG_PRINTLN("DJ Hero - Lucio v1.0.1");
+	DEBUG_PRINTLN("DJ Hero - Lucio v1.0.2");
 	DEBUG_PRINTLN("By David Madison, (c) 2018");
 	DEBUG_PRINTLN("http://www.partsnotincluded.com");
 	DEBUG_PRINTLN("----------------------------");

--- a/Arduino/DJLucio/DJLucio_ConfigMode.h
+++ b/Arduino/DJLucio/DJLucio_ConfigMode.h
@@ -39,8 +39,8 @@ extern DJTurntableController::TurntableExpansion * altTable;
 // TurntableConfig: Handles switching between "main" and "alternate" sides of the turntable
 class TurntableConfig {
 public:
-	typedef boolean(DJTurntableController::Data::*DJFunction)(void) const;  // Wrapper for the body function pointer
-	typedef boolean(DJTurntableController::Data::TurntableExpansion::*ExpansionFunction)(void) const;  // Wrapper for the expansion function pointers
+	typedef boolean(DJTurntableController::*DJFunction)(void) const;  // Wrapper for the body function pointer
+	typedef boolean(DJTurntableController::TurntableExpansion::*ExpansionFunction)(void) const;  // Wrapper for the expansion function pointers
 	typedef DJTurntableController::TurntableConfig Config;  // Wrapper for the config side enum
 
 	TurntableConfig(DJTurntableController &obj, DJFunction baseFunc, ExpansionFunction exFunc, unsigned long t)

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ This project allows a user to play the character of [Lucio](https://playoverwatc
 For more information, check out the blog post on [PartsNotIncluded.com](http://www.partsnotincluded.com/altctrl/playing-lucio-with-a-dj-hero-turntable).
 
 ## Dependencies
-The DJ Hero Lucio program uses my [NintendoExtensionCtrl library](https://github.com/dmadison/NintendoExtensionCtrl/) ([0.5.4](https://github.com/dmadison/NintendoExtensionCtrl/releases/tag/v0.5.4)) to handle communication to the DJ Hero controller itself.
+The DJ Hero Lucio program uses my [NintendoExtensionCtrl library](https://github.com/dmadison/NintendoExtensionCtrl/) ([0.7.1](https://github.com/dmadison/NintendoExtensionCtrl/releases/tag/v0.7.1)) to handle communication to the DJ Hero controller itself.
 
-This program was compiled using version [1.8.5](https://www.arduino.cc/en/Main/OldSoftwareReleases) of the [Arduino IDE](https://www.arduino.cc/en/Main/Software). If using an Arduino board such as the Leonardo or Pro Micro, the program is dependent on the Arduino Keyboard, Mouse, and Wire libraries which are installed with the IDE. If using a Teensy microcontroller, the program was built using [Teensyduino 1.42](https://www.pjrc.com/teensyduino-1-42-whats-new/) which you can download [here](https://www.pjrc.com/teensy/td_142), and also requires the [i2c_t3 library](https://github.com/nox771/i2c_t3) version [10.1](https://github.com/nox771/i2c_t3/releases/tag/v10.1).
+This program was compiled using version [1.8.6](https://www.arduino.cc/en/Main/OldSoftwareReleases) of the [Arduino IDE](https://www.arduino.cc/en/Main/Software). If using an Arduino board such as the Leonardo or Pro Micro, the program is dependent on the Arduino Keyboard, Mouse, and Wire libraries which are installed with the IDE. If using a Teensy microcontroller, the program was built using [Teensyduino 1.44](https://www.pjrc.com/teensyduino-1-44-released/) which you can download [here](https://www.pjrc.com/teensy/td_144), and also requires the [i2c_t3 library](https://github.com/nox771/i2c_t3) version [10.1](https://github.com/nox771/i2c_t3/releases/tag/v10.1).
 
 I've linked to the specific library releases that work with this code. Note that other versions may not be compatible.
 


### PR DESCRIPTION
I've recently completed a significant rework of the NintendoExtensionCtrl library which breaks the current code, as the `Data` typedef has been replaced by `Shared`. I've changed the relevant lines and since I'm building with updated tools I've updated the dependency list in the README to the versions I'm currently using.