### PR TITLE
Updated Dependencies (1.03)

### DIFF
--- a/Arduino/DJLucio/DJLucio.ino
+++ b/Arduino/DJLucio/DJLucio.ino
@@ -79,7 +79,7 @@ void setup() {
 	#ifdef DEBUG
 	Serial.begin(115200);
 	while (!Serial);  // Wait for connection
-	DEBUG_PRINTLN("DJ Hero - Lucio v1.0.2");
+	DEBUG_PRINTLN("DJ Hero - Lucio v1.0.3");
 	DEBUG_PRINTLN("By David Madison, (c) 2018");
 	DEBUG_PRINTLN("http://www.partsnotincluded.com");
 	DEBUG_PRINTLN("----------------------------");

--- a/Arduino/DJLucio/DJLucio.ino
+++ b/Arduino/DJLucio/DJLucio.ino
@@ -167,7 +167,7 @@ void djController() {
 	// Abilities
 	ultimate.press(dj.buttonEuphoria());
 	amp.press(fx.changed(EffectThreshold) && fx.getTotal() > 0);
-	crossfade.press(dj.crossfadeSlider() > 1);
+	crossfade.press(dj.crossfadeSlider() > 9);  // 7/8 is centered
 
 	// Fun stuff!
 	emotes.press(dj.buttonPlus());

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # DJ Hero Lucio
 This project allows a user to play the character of [Lucio](https://playoverwatch.com/en-us/heroes/lucio/) in *Overwatch* using an Arduino and a DJ Hero turntable for the Nintendo Wii.
 
-For more information, check out the blog post on [PartsNotIncluded.com](http://www.partsnotincluded.com/altctrl/playing-lucio-with-a-dj-hero-turntable).
+For more information, check out the blog post on [PartsNotIncluded.com](https://www.partsnotincluded.com/playing-lucio-with-a-dj-hero-turntable/).
 
 ## Dependencies
 The DJ Hero Lucio program uses my [NintendoExtensionCtrl library](https://github.com/dmadison/NintendoExtensionCtrl/) ([0.7.1](https://github.com/dmadison/NintendoExtensionCtrl/releases/tag/v0.7.1)) to handle communication to the DJ Hero controller itself.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This project allows a user to play the character of [Lucio](https://playoverwatc
 For more information, check out the blog post on [PartsNotIncluded.com](https://www.partsnotincluded.com/playing-lucio-with-a-dj-hero-turntable/).
 
 ## Dependencies
-The DJ Hero Lucio program uses my [NintendoExtensionCtrl library](https://github.com/dmadison/NintendoExtensionCtrl/) ([0.7.1](https://github.com/dmadison/NintendoExtensionCtrl/releases/tag/v0.7.1)) to handle communication to the DJ Hero controller itself.
+The DJ Hero Lucio program uses my [NintendoExtensionCtrl library](https://github.com/dmadison/NintendoExtensionCtrl/) ([0.7.4](https://github.com/dmadison/NintendoExtensionCtrl/releases/tag/v0.7.4)) to handle communication to the DJ Hero controller itself.
 
 This program was compiled using version [1.8.6](https://www.arduino.cc/en/Main/OldSoftwareReleases) of the [Arduino IDE](https://www.arduino.cc/en/Main/Software). If using an Arduino board such as the Leonardo or Pro Micro, the program is dependent on the Arduino Keyboard, Mouse, and Wire libraries which are installed with the IDE. If using a Teensy microcontroller, the program was built using [Teensyduino 1.44](https://www.pjrc.com/teensyduino-1-44-released/) which you can download [here](https://www.pjrc.com/teensy/td_144), and also requires the [i2c_t3 library](https://github.com/nox771/i2c_t3) version [10.1](https://github.com/nox771/i2c_t3/releases/tag/v10.1).
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ For more information, check out the blog post on [PartsNotIncluded.com](https://
 ## Dependencies
 The DJ Hero Lucio program uses my [NintendoExtensionCtrl library](https://github.com/dmadison/NintendoExtensionCtrl/) ([0.7.4](https://github.com/dmadison/NintendoExtensionCtrl/releases/tag/v0.7.4)) to handle communication to the DJ Hero controller itself.
 
-This program was compiled using version [1.8.6](https://www.arduino.cc/en/Main/OldSoftwareReleases) of the [Arduino IDE](https://www.arduino.cc/en/Main/Software). If using an Arduino board such as the Leonardo or Pro Micro, the program is dependent on the Arduino Keyboard, Mouse, and Wire libraries which are installed with the IDE. If using a Teensy microcontroller, the program was built using [Teensyduino 1.44](https://www.pjrc.com/teensyduino-1-44-released/) which you can download [here](https://www.pjrc.com/teensy/td_144), and also requires the [i2c_t3 library](https://github.com/nox771/i2c_t3) version [10.1](https://github.com/nox771/i2c_t3/releases/tag/v10.1).
+This program was compiled using version [1.8.8](https://www.arduino.cc/en/Main/OldSoftwareReleases) of the [Arduino IDE](https://www.arduino.cc/en/Main/Software). If using an Arduino board such as the Leonardo or Pro Micro, the program is dependent on the Arduino Keyboard, Mouse, and Wire libraries which are installed with the IDE. If using a Teensy microcontroller, the program was built using [Teensyduino 1.45](https://forum.pjrc.com/threads/54557-Teensyduino-1-45-Released) which you can download [here](https://www.pjrc.com/teensy/td_145), and also requires the [i2c_t3 library](https://github.com/nox771/i2c_t3) version [10.1](https://github.com/nox771/i2c_t3/releases/tag/v10.1).
 
-I've linked to the specific library releases that work with this code. Note that other versions may not be compatible.
+I've linked to the specific releases that I used to compile this code. Note that other versions may not be compatible.
 
 ## License
 This project is licensed under the terms of the [GNU General Public License](https://www.gnu.org/licenses/gpl-3.0.en.html), either version 3 of the License, or (at your option) any later version.


### PR DESCRIPTION
I'm currently messing with the DJ Hero turntable again so I'm updating this for posterity.

This pull request updates the NintendoExtensionCtrl dependency to work with the latest version [0.7.4](https://github.com/dmadison/NintendoExtensionCtrl/releases/tag/v0.7.4), which changes the output range of the `crossfadeSlider()` function.

Since I've also recompiled the code, I've updated the dependency list in the README with what's currently installed on my system.